### PR TITLE
fix: print listen address on start.

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,8 +79,9 @@ func startServer() {
 	}
 
 	go func() {
+		log.Printf("listen address %q\n", srv.Addr)
 		if err := srv.ListenAndServe(); err != nil {
-			log.Printf("listen: %s\n", err)
+			log.Fatalf("start failed: %s\n", err)
 		}
 	}()
 


### PR DESCRIPTION
原来代码 启动后 也不打印 监听地址 (端口), 配置文件 也没有, 要去 `main.go` 才能找到 地址是啥.

加上了 启动时 打印 listen 的 地址的日志.